### PR TITLE
Avoid clobbering Install-Module

### DIFF
--- a/vendor/profile.ps1
+++ b/vendor/profile.ps1
@@ -17,10 +17,14 @@ if(!$PSScriptRoot) {
     $PSScriptRoot = Split-Path $Script:MyInvocation.MyCommand.Path
 }
 
+# do not load bundled psget if a module installer is already available
+# -> recent PowerShell versions include PowerShellGet out of the box
+$moduleInstallerAvailable = [bool](Get-Command -Name 'Install-Module' -ErrorAction SilentlyContinue | Out-Null)
+
 # Add Cmder modules directory to the autoload path.
 $CmderModulePath = Join-path $PSScriptRoot "psmodules/"
 
-if( -not $env:PSModulePath.Contains($CmderModulePath) ){
+if(-not $moduleInstallerAvailable -and -not $env:PSModulePath.Contains($CmderModulePath) ){
     $env:PSModulePath = $env:PSModulePath.Insert(0, "$CmderModulePath;")
 }
 


### PR DESCRIPTION
If the Install-Module command is available, do not include the bundled
module path containing a deprecated version of PSGet. Recent powershell
versions include PowerShellGet as standard module installer.

Resolves #1318.